### PR TITLE
Makefile: add dummy all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: install uninstall
+.PHONY: all install uninstall
+
+all:
+	
 
 install:
 	mkdir -p /usr/lib/systemd/system


### PR DESCRIPTION
* allow execution of "make" as non-root
* eases integration in packaging tools