### PR TITLE
Fix issue #12 - netnsinit fails if gateway not set

### DIFF
--- a/scripts/netnsinit
+++ b/scripts/netnsinit
@@ -9,19 +9,29 @@ display_usage() {
 }
 
 autoconfigure_tunnel() {
-	[ ! -z "$MACADDR" ] && /bin/ip link set ${DEVNAME_INSIDE} address ${MACADDR}
+	if [ ! -z "$MACADDR" ]; then
+		/bin/ip link set ${DEVNAME_INSIDE} address ${MACADDR}
+	fi
 	if [ "${DHCPV4}" == "1" ]; then
 		! mkdir -p /var/run/netns
 		dhclient -v -i ${DEVNAME_INSIDE} -nw -pf /var/run/netns/dhclient-${NSNAME}.pid
 	else
-		[ ! -z "${IPADDR}" ] && /bin/ip address add ${IPADDR} dev ${DEVNAME_INSIDE}
-		[ ! -z "${GATEWAY}" ] && /bin/ip route add default via ${GATEWAY%%/*}
+		if [ ! -z "${IPADDR}" ]; then
+			/bin/ip address add ${IPADDR} dev ${DEVNAME_INSIDE}
+		fi
+		if [ ! -z "${GATEWAY}" ]; then
+			/bin/ip route add default via ${GATEWAY%%/*}
+		fi
 	fi
+	return 0 # additional precation against "set -e" in case of future mods of this function
 }
 
 autoconfigure_nat() {
 	# add default route if gateway undefined
-	[ -z "${GATEWAY}" -a -n "${IPADDR_OUTSIDE}" ] && /bin/ip route add default via ${IPADDR_OUTSIDE%%/*}
+	if [ -z "${GATEWAY}" -a -n "${IPADDR_OUTSIDE}" ]; then
+		/bin/ip route add default via ${IPADDR_OUTSIDE%%/*}
+	fi
+	return 0 # additional precation against "set -e" in case of future mods of this function
 }
 
 autoconfigure() {


### PR DESCRIPTION
Closes https://github.com/Jamesits/systemd-named-netns/issues/12

"set -e" does not play well with shorthand "if" checks "[ a ] && b"
inside functions due to how exit code propagates to function exit code.
No such issue when using normal if-then because in such case exit code
is not set to 1 when check fails.
Additionally added "return 0" just in case future update to functions
add more potentially failty code - this is enough to prevent it from
failing. Not needed in current version though.