### PR TITLE
Fix uninstaller for Arch Linux, systemd 239

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,11 @@ install:
 	systemctl daemon-reload || true
 
 uninstall:
-	systemctl disable --now "netns-tunnel@*.service" || true
-	systemctl disable --now "netns-bridge@*.service" || true
-	systemctl disable --now "netns-nat@*.service" || true
-	systemctl disable --now "netns@*.service" || true
+	systemctl disable "netns-tunnel@" || true
+	systemctl disable "netns-bridge@" || true
+	systemctl disable "netns-nat@" || true
+	systemctl disable "netns@" || true
+
 	rm -f $(DESTDIR)/$(LIBDIR)/systemd/system/netns@.service
 	rm -f $(DESTDIR)/$(LIBDIR)/systemd/system/netns-bridge@.service
 	rm -f $(DESTDIR)/$(LIBDIR)/systemd/system/netns-nat@.service


### PR DESCRIPTION
using asterisk causes error "Invalid unit name "netns-tunnel@*" was escaped as "netns-tunnel@\x2a" (maybe you should use systemd-escape?)". The fix may not work for older systemd or for other reasons, please double-check, maybe add both variants if this doesn't work for you (it works for me, disables all units, tested by enabling several nents-tunnel@test1 nents-tunnel@test2 etc).