### PR TITLE
Added support for MACVLAN Bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project enables you to:
  * Use named netns in systemd services
    * Enables them to connect to the internet too
    * And you can manually switch to its netns (since they are named)
-   
+
 ## Installation
 
 Dependencies:
@@ -16,7 +16,7 @@ Dependencies:
  * iptables (only if you use default NAT config)
  * `/usr/bin/env`
 
-For installation, run `make install` with root privilege. 
+For installation, run `make install` with root privilege.
 
 You ran run `make uninstall` to remove the systemd units, but the configs located in `/etc/default` will not be removed.
 
@@ -26,6 +26,21 @@ You ran run `make uninstall` to remove the systemd units, but the configs locate
 systemctl start netns-nat@helloworld
 chnetns helloworld ip address
 ```
+
+## NSTypes
+
+### Tunnel (netns-tunnel)
+
+### Bridge (netns-bridge)
+
+### MACVLAN Bridge (netns-mvbr)
+Alternative to NSType tunnel. A [MACVLAN Bridge](https://developers.redhat.com/blog/2018/10/22/introduction-to-linux-interfaces-for-virtual-networking/#macvlan) allows you to create multiple interfaces with different Layer 2 (that is, Ethernet MAC) addresses on top of a single NIC.
+
+For netns-mvbr, `${MACVLAN_BRIDGE}` will be the bridge device (usually your physical NIC device).
+
+Note that any MACVLAN devices in other netnss will be able to communicate each other and the outside world but NOT the bridge device. If you want to enable communication with the root netns, you can add a MACVLAN device in the root netns and use that instead of the MACVLAN bridge device.
+
+### NAT (netns-nat)
 
 ## Resources
 

--- a/configs/netns
+++ b/configs/netns
@@ -7,6 +7,9 @@
 # Bridge name for netns-bridge@.service
 #BRIDGE=br0
 
+# MACVLAN bridge device for netns-mvbr@.service
+#MACVLAN_BRIDGE=eth0
+
 # IP address of the interface outside
 #IPADDR_OUTSIDE=192.168.1.1/24
 

--- a/scripts/netnsinit
+++ b/scripts/netnsinit
@@ -58,7 +58,7 @@ autoconfigure() {
 
 	echo "Starting autoconfigure for $NSTYPE ${NSNAME}"
 	if [ "$NSTYPE" == "mvbr" ]; then
-		DEVNAME_INSIDE=mv-${NSNAME}0
+		DEVNAME_INSIDE=mv0
 	else
 		DEVNAME_INSIDE=vn-${NSNAME}1
 		DEVNAME_OUTSIDE=vn-${NSNAME}0

--- a/scripts/netnsinit
+++ b/scripts/netnsinit
@@ -32,7 +32,7 @@ autoconfigure_nat() {
 	if [ -z "${GATEWAY}" -a -n "${IPADDR_OUTSIDE}" ]; then
 		/bin/ip route add default via ${IPADDR_OUTSIDE%%/*}
 	fi
-	
+
 	return 0 # additional precation against "set -e" in case of future mods of this function
 }
 
@@ -44,12 +44,12 @@ autoconfigure_nat-access() {
 	if [ "$3" == "up" ]; then
 		#Accept related traffic
 		iptables -I INPUT -i ${DEVNAME_OUTSIDE} -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-		
+
 	elif  [ "$3" == "down" ]; then
 		iptables -D INPUT -i ${DEVNAME_OUTSIDE} -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 	fi
-	
-	
+
+
 	return 0 # additional precation against "set -e" in case of future mods of this function
 }
 autoconfigure() {
@@ -57,14 +57,19 @@ autoconfigure() {
 	local NSNAME=$2
 
 	echo "Starting autoconfigure for $NSTYPE ${NSNAME}"
-	DEVNAME_INSIDE=vn-${NSNAME}1
-	DEVNAME_OUTSIDE=vn-${NSNAME}0
-	
+	if [ "$NSTYPE" == "mvbr" ]; then
+		DEVNAME_INSIDE=mv-${NSNAME}0
+	else
+		DEVNAME_INSIDE=vn-${NSNAME}1
+		DEVNAME_OUTSIDE=vn-${NSNAME}0
+	fi
+
 	source /etc/default/netns
 	! source "/etc/default/netns-${NSNAME}"
 
-	if type -t autoconfigure_$NSTYPE >/dev/null ; then
-		autoconfigure_$NSTYPE "$@"
+	[[ $NSTYPE = "mvbr" ]] && SETUPTYPE="tunnel" || SETUPTYPE=$NSTYPE
+	if type -t autoconfigure_$SETUPTYPE >/dev/null ; then
+		autoconfigure_$SETUPTYPE "$@"
 	fi
 
 	echo "Autoconfiguration finished."
@@ -80,7 +85,7 @@ case "$1" in
 		display_usage
 		exit 0
 		;;
-	"tunnel"|"bridge"|"nat"|"nat-access")
+	"tunnel"|"bridge"|"mvbr"|"nat"|"nat-access")
 		autoconfigure "$@"
 		exit 0
 		;;

--- a/services/netns-mvbr@.service
+++ b/services/netns-mvbr@.service
@@ -14,15 +14,16 @@ WantedBy=multi-user.target
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-Environment=DEVNAME_INSIDE=mv-%I0
+Environment=DEVNAME_INSIDE=mv0
+Environment=DEVNAME_INSIDE_TMP_SUFFIX="-%I-tmp"
 EnvironmentFile=/etc/default/netns
 EnvironmentFile=-/etc/default/netns-%I
 
-ExecStartPre=-/usr/bin/env ip link delete ${DEVNAME_INSIDE}
+ExecStartPre=-/usr/bin/env ip -n %I link delete ${DEVNAME_INSIDE}
 
-ExecStart=/usr/bin/env ip link add ${DEVNAME_INSIDE} link ${MACVLAN_BRIDGE} type macvlan mode bridge
-ExecStart=-/usr/bin/env tc qdisc del dev ${DEVNAME_INSIDE} root
-ExecStart=/usr/bin/env ip link set ${DEVNAME_INSIDE} netns %I
+ExecStart=/usr/bin/env ip link add ${DEVNAME_INSIDE}${DEVNAME_INSIDE_TMP_SUFFIX} netns %I link ${MACVLAN_BRIDGE} type macvlan mode bridge
+ExecStart=/usr/bin/env ip -n %I link set dev ${DEVNAME_INSIDE}${DEVNAME_INSIDE_TMP_SUFFIX} name ${DEVNAME_INSIDE}
+ExecStart=-/usr/bin/env tc -n %I qdisc del dev ${DEVNAME_INSIDE} root
 ExecStart=/usr/bin/env ip -n %I link set ${DEVNAME_INSIDE} up
 
 # do not run in ExecStartPost to prevent forked dhclient from being killed
@@ -30,4 +31,4 @@ ExecStart=/usr/bin/env ip netns exec %I /usr/bin/env netnsinit mvbr %I
 
 ExecStop=-/usr/bin/env kill -15 `cat /var/run/netns/dhclient-%i.pid`
 ExecStop=-/usr/bin/env rm /var/run/netns/dhclient-%i.pid
-ExecStop=-/usr/bin/env ip link delete ${DEVNAME_INSIDE}
+ExecStop=-/usr/bin/env ip -n %I link delete ${DEVNAME_INSIDE}

--- a/services/netns-mvbr@.service
+++ b/services/netns-mvbr@.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Macvlan-bridging service for netns %I
+Documentation=https://github.com/Jamesits/systemd-named-netns
+
+BindsTo=netns@%i.service
+After=netns@%i.service
+Before=network.target network-online.target
+Conflicts=netns-tunnel@%i.service
+
+[Install]
+WantedBy=network-online.target
+WantedBy=multi-user.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment=DEVNAME_INSIDE=mv-%I0
+EnvironmentFile=/etc/default/netns
+EnvironmentFile=-/etc/default/netns-%I
+
+ExecStartPre=-/usr/bin/env ip link delete ${DEVNAME_INSIDE}
+
+ExecStart=/usr/bin/env ip link add ${DEVNAME_INSIDE} link ${MACVLAN_BRIDGE} type macvlan mode bridge
+ExecStart=-/usr/bin/env tc qdisc del dev ${DEVNAME_INSIDE} root
+ExecStart=/usr/bin/env ip link set ${DEVNAME_INSIDE} netns %I
+ExecStart=/usr/bin/env ip -n %I link set ${DEVNAME_INSIDE} up
+
+# do not run in ExecStartPost to prevent forked dhclient from being killed
+ExecStart=/usr/bin/env ip netns exec %I /usr/bin/env netnsinit mvbr %I
+
+ExecStop=-/usr/bin/env kill -15 `cat /var/run/netns/dhclient-%i.pid`
+ExecStop=-/usr/bin/env rm /var/run/netns/dhclient-%i.pid
+ExecStop=-/usr/bin/env ip link delete ${DEVNAME_INSIDE}


### PR DESCRIPTION
I added support for MACVLAN Bridges. You may want to remove my changes to README.md and move them into the wiki for consistency.

To use, Add `MACVLAN_BRIDGE=eth0` or whatever interface you wish to use as the MACVLAN bridge to your /etc/defaults/netns* and start the service `systemctl start netns-mvbr@mvbtest.service`.
