### PR TITLE
Corrected config loading

### DIFF
--- a/scripts/netnsinit
+++ b/scripts/netnsinit
@@ -32,7 +32,7 @@ autoconfigure_nat() {
 	if [ -z "${GATEWAY}" -a -n "${IPADDR_OUTSIDE}" ]; then
 		/bin/ip route add default via ${IPADDR_OUTSIDE%%/*}
 	fi
-	
+
 	return 0 # additional precation against "set -e" in case of future mods of this function
 }
 
@@ -44,12 +44,12 @@ autoconfigure_nat-access() {
 	if [ "$3" == "up" ]; then
 		#Accept related traffic
 		iptables -I INPUT -i ${DEVNAME_OUTSIDE} -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-		
+
 	elif  [ "$3" == "down" ]; then
 		iptables -D INPUT -i ${DEVNAME_OUTSIDE} -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 	fi
-	
-	
+
+
 	return 0 # additional precation against "set -e" in case of future mods of this function
 }
 autoconfigure() {
@@ -59,9 +59,10 @@ autoconfigure() {
 	echo "Starting autoconfigure for $NSTYPE ${NSNAME}"
 	DEVNAME_INSIDE=vn-${NSNAME}1
 	DEVNAME_OUTSIDE=vn-${NSNAME}0
-	
+
 	source /etc/default/netns
-	! source "/etc/default/netns-${NSNAME}"
+	! source "/etc/default/netns-${NSTYPE}"
+	! source "/etc/default/netns-${NSTYPE}-${NSNAME}"
 
 	if type -t autoconfigure_$NSTYPE >/dev/null ; then
 		autoconfigure_$NSTYPE "$@"


### PR DESCRIPTION
The [docs](https://github.com/Jamesits/systemd-named-netns/wiki/Config) describe loading the config from `/etc/defaults/netns` then overriding those with `/etc/defaults/netns-<type>` and finally overriding those with `/etc/defaults/netns-<type>-<nsname>`. The currently the code only overrides `/etc/defaults/netns` with `/etc/defaults/netns-<nsname>`.

This patch would do what is described in the docs. Note that it's not backwards compatible with the old config names. You could also override with `/etc/defaults/netns-<nsname>` as well but you could run into naming conflicts with `nstype` and `nsname`.