### PR TITLE
Shellcheck fixes and some bugfixes

### DIFF
--- a/scripts/netnsinit
+++ b/scripts/netnsinit
@@ -107,7 +107,7 @@ autoconfigure_nat_up_inside() {
 	autoconfigure_tunnel_up_inside
 
 	# add default route if gateway undefined
-	if [ -z "${GATEWAY}" -a -n "${IPADDR_OUTSIDE}" ]; then
+	if [ -z "${GATEWAY}" ] && [ -n "${IPADDR_OUTSIDE}" ]; then
 		GATEWAY="${IPADDR_OUTSIDE}"
 	fi
 

--- a/scripts/netnsinit
+++ b/scripts/netnsinit
@@ -12,22 +12,22 @@ display_usage() {
 
 autoconfigure_tunnel_up_outside() {
 	# precaution
-	! ip link delete ${DEVNAME_OUTSIDE}
-	! ip link delete ${DEVNAME_INSIDE}
+	! ip link delete "${DEVNAME_OUTSIDE}"
+	! ip link delete "${DEVNAME_INSIDE}"
 
 	# setup pseudo wire
-	ip link add ${DEVNAME_OUTSIDE} type veth peer name ${DEVNAME_INSIDE}
-	! tc qdisc del dev ${DEVNAME_INSIDE} root
+	ip link add "${DEVNAME_OUTSIDE}" type veth peer name "${DEVNAME_INSIDE}"
+	! tc qdisc del dev "${DEVNAME_INSIDE}" root
 	if [ ! -z "$MACADDR" ]; then
-		ip link set ${DEVNAME_INSIDE} address ${MACADDR}
+		ip link set "${DEVNAME_INSIDE}" address "${MACADDR}"
 	fi
-	ip link set ${DEVNAME_INSIDE} netns ${NSNAME}
-	ip link set ${DEVNAME_OUTSIDE} up
-	ip -n ${NSNAME} link set ${DEVNAME_INSIDE} up
+	ip link set "${DEVNAME_INSIDE}" netns "${NSNAME}"
+	ip link set "${DEVNAME_OUTSIDE}" up
+	ip -n "${NSNAME}" link set "${DEVNAME_INSIDE}" up
 
 	# add ipv4 address at global end
 	if [ ! -z "${IPADDR_OUTSIDE}" ]; then
-		ip address add ${IPADDR_OUTSIDE} dev ${DEVNAME_OUTSIDE}
+		ip address add "${IPADDR_OUTSIDE}" dev "${DEVNAME_OUTSIDE}"
 	fi
 
 	return 0 # additional precation against "set -e" in case of future mods of this function
@@ -36,18 +36,18 @@ autoconfigure_tunnel_up_outside() {
 autoconfigure_tunnel_up_inside() {
 	# add ipv4 address at netns end
 	if [ ! -z "${IPADDR}" ]; then
-		ip address add ${IPADDR} dev ${DEVNAME_INSIDE}
+		ip address add "${IPADDR}" dev "${DEVNAME_INSIDE}"
 	fi
 
 	# setup default route
 	if [ ! -z "${GATEWAY}" ]; then
-		ip route add default via ${GATEWAY%%/*} dev ${DEVNAME_INSIDE} onlink
+		ip route add default via "${GATEWAY%%/*}" dev "${DEVNAME_INSIDE}" onlink
 	fi
 
 	# if DHCP is configured
 	if [ "${DHCPV4}" == "1" ]; then
 		! mkdir -p /var/run/netns
-		dhclient -v -i ${DEVNAME_INSIDE} -nw -pf /var/run/netns/dhclient-${NSNAME}.pid
+		dhclient -v -i "${DEVNAME_INSIDE}" -nw -pf "/var/run/netns/dhclient-${NSNAME}.pid"
 	fi
 
 	return 0
@@ -56,18 +56,18 @@ autoconfigure_tunnel_up_inside() {
 autoconfigure_tunnel_down_inside() {
 	# kill DHCP client
 	# do not run in ExecStartPost to prevent forked dhclient from being killed
-	! kill -15 `cat /var/run/netns/dhclient-${NSNAME}.pid`
-	! rm /var/run/netns/dhclient-${NSNAME}.pid
+	! kill -15 "`cat /var/run/netns/dhclient-"${NSNAME}".pid`"
+	! rm "/var/run/netns/dhclient-${NSNAME}.pid"
 }
 
 autoconfigure_tunnel_down_outside() {
-	ip link delete ${DEVNAME_OUTSIDE}
+	ip link delete "${DEVNAME_OUTSIDE}"
 }
 
 autoconfigure_bridge_up_outside() {
 	autoconfigure_tunnel_up_outside
 
-	ip link set ${DEVNAME_OUTSIDE} master ${BRIDGE}
+	ip link set "${DEVNAME_OUTSIDE}" master "${BRIDGE}"
 }
 
 autoconfigure_bridge_up_inside() {
@@ -91,13 +91,13 @@ autoconfigure_nat_up_outside() {
 
 	# set up NAT
 	# in POSTROUTING we cannot select via source interface, so we use source ip address here
-	iptables -t nat -A POSTROUTING -s ${IPADDR_OUTSIDE} -j MASQUERADE
+	iptables -t nat -A POSTROUTING -s "${IPADDR_OUTSIDE}" -j MASQUERADE
 
 	if [ "${NAT_ACCEPT_TRAFFIC}" == "1" ]; then
-		iptables -A FORWARD -i ${DEVNAME_OUTSIDE} -j ACCEPT
-		iptables -A FORWARD -o ${DEVNAME_OUTSIDE} -j ACCEPT
+		iptables -A FORWARD -i "${DEVNAME_OUTSIDE}" -j ACCEPT
+		iptables -A FORWARD -o "${DEVNAME_OUTSIDE}" -j ACCEPT
 		#Accept related traffic
-		iptables -I INPUT -i ${DEVNAME_OUTSIDE} -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+		iptables -I INPUT -i "${DEVNAME_OUTSIDE}" -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 	fi
 
 	return 0 # additional precation against "set -e" in case of future mods of this function
@@ -105,7 +105,7 @@ autoconfigure_nat_up_outside() {
 
 autoconfigure_nat_up_inside() {
 	autoconfigure_tunnel_up_inside
-	
+
 	# add default route if gateway undefined
 	if [ -z "${GATEWAY}" -a -n "${IPADDR_OUTSIDE}" ]; then
 		GATEWAY="${IPADDR_OUTSIDE}"
@@ -122,11 +122,11 @@ autoconfigure_nat_down_inside() {
 
 autoconfigure_nat_down_outside() {
 	# remove NAT
-	iptables -t nat -D POSTROUTING -s ${IPADDR_OUTSIDE} -j MASQUERADE
+	iptables -t nat -D POSTROUTING -s "${IPADDR_OUTSIDE}" -j MASQUERADE
 
-	iptables -D FORWARD -i ${DEVNAME_OUTSIDE} -j ACCEPT
-	iptables -D FORWARD -o ${DEVNAME_OUTSIDE} -j ACCEPT
-	iptables -D INPUT -i ${DEVNAME_OUTSIDE} -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+	iptables -D FORWARD -i "${DEVNAME_OUTSIDE}" -j ACCEPT
+	iptables -D FORWARD -o "${DEVNAME_OUTSIDE}" -j ACCEPT
+	iptables -D INPUT -i "${DEVNAME_OUTSIDE}" -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 
 	autoconfigure_tunnel_down_outside
 
@@ -137,11 +137,11 @@ autoconfigure_mvbr_up_outside() {
 	DEVNAME_INSIDE=mv0
 	DEVNAME_INSIDE_TMP_SUFFIX="-${NSNAME}"
 
-	! ip -n ${NSNAME} link delete ${DEVNAME_INSIDE}
-	ip link add ${DEVNAME_INSIDE}${DEVNAME_INSIDE_TMP_SUFFIX} netns ${NSNAME} link ${MACVLAN_BRIDGE} type macvlan mode bridge
-	ip -n ${NSNAME} link set dev ${DEVNAME_INSIDE}${DEVNAME_INSIDE_TMP_SUFFIX} name ${DEVNAME_INSIDE}
-	! tc -n ${NSNAME} qdisc del dev ${DEVNAME_INSIDE} root
-	ip -n ${NSNAME} link set ${DEVNAME_INSIDE} up
+	! ip -n "${NSNAME}" link delete "${DEVNAME_INSIDE}"
+	ip link add "${DEVNAME_INSIDE}${DEVNAME_INSIDE_TMP_SUFFIX}" netns "${NSNAME}" link "${MACVLAN_BRIDGE}" type macvlan mode bridge
+	ip -n "${NSNAME}" link set dev "${DEVNAME_INSIDE}${DEVNAME_INSIDE_TMP_SUFFIX}" name ${DEVNAME_INSIDE}
+	! tc -n "${NSNAME}" qdisc del dev "${DEVNAME_INSIDE}" root
+	ip -n "${NSNAME}" link set "${DEVNAME_INSIDE}" up
 
 	autoconfigure_tunnel_up_outside
 }
@@ -149,7 +149,7 @@ autoconfigure_mvbr_up_outside() {
 autoconfigure_mvbr_down_outside() {
 	autoconfigure_tunnel_down_outside
 
-	ip -n ${NSNAME} link delete ${DEVNAME_INSIDE}
+	ip -n "${NSNAME}" link delete ${DEVNAME_INSIDE}
 }
 
 autoconfigure() {
@@ -159,7 +159,7 @@ autoconfigure() {
 	INOUT=$4
 
 	echo "Starting autoconfigure for ${NSTYPE} ${NSNAME}"
-  
+
 	DEVNAME_INSIDE=vn-${NSNAME}1
 	DEVNAME_OUTSIDE=vn-${NSNAME}0
 
@@ -168,8 +168,8 @@ autoconfigure() {
 	! source "/etc/default/netns-${NSNAME}" # for compatibility, see https://github.com/Jamesits/systemd-named-netns/pull/21
 	! source "/etc/default/netns-${NSTYPE}-${NSNAME}"
 
-	if type -t autoconfigure_${NSTYPE}_${UPDOWN}_${INOUT} >/dev/null ; then
-		autoconfigure_${NSTYPE}_${UPDOWN}_${INOUT} "$@"
+	if type -t autoconfigure_"${NSTYPE}_${UPDOWN}_${INOUT}" >/dev/null ; then
+		autoconfigure_"${NSTYPE}_${UPDOWN}_${INOUT}" "$@"
 		echo "Autoconfiguration finished."
 	else
 		echo "No configuration required."

--- a/scripts/netnsinit
+++ b/scripts/netnsinit
@@ -21,7 +21,7 @@ autoconfigure_tunnel_up_outside() {
 	if [ -n "$MACADDR" ]; then
 		ip link set "${DEVNAME_INSIDE}" address "${MACADDR}"
 	fi
-	ip link set "${DEVNAME_INSIDE}" netns "${NSNAME}"
+	! ip link set "${DEVNAME_INSIDE}" netns "${NSNAME}" # apparently the link may already have the netns set
 	ip link set "${DEVNAME_OUTSIDE}" up
 	ip -n "${NSNAME}" link set "${DEVNAME_INSIDE}" up
 

--- a/scripts/netnsinit
+++ b/scripts/netnsinit
@@ -18,7 +18,7 @@ autoconfigure_tunnel_up_outside() {
 	# setup pseudo wire
 	ip link add "${DEVNAME_OUTSIDE}" type veth peer name "${DEVNAME_INSIDE}"
 	! tc qdisc del dev "${DEVNAME_INSIDE}" root
-	if [ ! -z "$MACADDR" ]; then
+	if [ -n "$MACADDR" ]; then
 		ip link set "${DEVNAME_INSIDE}" address "${MACADDR}"
 	fi
 	ip link set "${DEVNAME_INSIDE}" netns "${NSNAME}"
@@ -26,7 +26,7 @@ autoconfigure_tunnel_up_outside() {
 	ip -n "${NSNAME}" link set "${DEVNAME_INSIDE}" up
 
 	# add ipv4 address at global end
-	if [ ! -z "${IPADDR_OUTSIDE}" ]; then
+	if [ -n "${IPADDR_OUTSIDE}" ]; then
 		ip address add "${IPADDR_OUTSIDE}" dev "${DEVNAME_OUTSIDE}"
 	fi
 
@@ -35,12 +35,12 @@ autoconfigure_tunnel_up_outside() {
 
 autoconfigure_tunnel_up_inside() {
 	# add ipv4 address at netns end
-	if [ ! -z "${IPADDR}" ]; then
+	if [ -n "${IPADDR}" ]; then
 		ip address add "${IPADDR}" dev "${DEVNAME_INSIDE}"
 	fi
 
 	# setup default route
-	if [ ! -z "${GATEWAY}" ]; then
+	if [ -n "${GATEWAY}" ]; then
 		ip route add default via "${GATEWAY%%/*}" dev "${DEVNAME_INSIDE}" onlink
 	fi
 

--- a/scripts/netnsinit
+++ b/scripts/netnsinit
@@ -56,7 +56,7 @@ autoconfigure_tunnel_up_inside() {
 autoconfigure_tunnel_down_inside() {
 	# kill DHCP client
 	# do not run in ExecStartPost to prevent forked dhclient from being killed
-	! kill -15 "`cat /var/run/netns/dhclient-"${NSNAME}".pid`"
+	! kill -15 "$(cat /var/run/netns/dhclient-"${NSNAME}".pid)"
 	! rm "/var/run/netns/dhclient-${NSNAME}.pid"
 }
 


### PR DESCRIPTION
Most of the fixes shellcheck alerted are not that much of a problem, but I don’t see a reason not to have them. Quoting especially often results to better error messages, as commands will receive empty string instead of one less argument. 

Last one (4bae49d) was necessary for me to get this working. I’m not completely sure why it was defined in first place. 